### PR TITLE
добавить комменты пользователя к странице плана

### DIFF
--- a/src/components/PlanReportBlock/PlanReportBlock.tsx
+++ b/src/components/PlanReportBlock/PlanReportBlock.tsx
@@ -17,9 +17,10 @@ type PlanReportBlockProps = {
   };
   isLoggedIn: boolean;
   text: string;
+  handleComment: (message: string) => void;
 };
 
-function PlanReportBlock({ plan, isLoggedIn, text }: PlanReportBlockProps) {
+function PlanReportBlock({ plan, isLoggedIn, text, handleComment }: PlanReportBlockProps) {
   const [showMore, setShowMore] = useState(false);
   const location = useLocation();
   const isWorkoutPlanPage = location.pathname === '/workout-plan';
@@ -51,7 +52,7 @@ function PlanReportBlock({ plan, isLoggedIn, text }: PlanReportBlockProps) {
           </div>
 
           {(isWorkoutPlanPage || isMealPlanPage) && (
-            <UserNoteForm title="Заметка за день" content={plan.user_comment || ''} />
+            <UserNoteForm title="Заметка за день" content={plan.user_comment || ''} handleComment={handleComment} />
           )}
         </>
       )}

--- a/src/components/UserNoteForm/UserNoteForm.tsx
+++ b/src/components/UserNoteForm/UserNoteForm.tsx
@@ -1,24 +1,36 @@
-import Button from '../Button/Button';
+import { useState } from 'react';
 import styles from './UserNoteForm.module.scss';
 
 type UserNoteFormProps = {
   title: string;
   content: string;
+  handleComment: (message: string) => void;
 };
 
-function UserNoteForm({ title, content }: UserNoteFormProps) {
+function UserNoteForm({ title, content, handleComment }: UserNoteFormProps) {
+  const [message, setMessage] = useState<string>(content);
+
+  function handleSubmit(evt: React.FormEvent) {
+    evt.preventDefault();
+    handleComment(message);
+  }
+
   return (
-    <div className={styles.userNoteForm}>
+    <form className={styles.userNoteForm} onSubmit={handleSubmit}>
       <p className={styles.userNoteForm__title}>{title}</p>
       <textarea
         className={styles.userNoteForm__input}
-        name=""
-        id=""
+        name="comment"
+        id="comment"
+        value={message}
         placeholder="Оставьте заметку об этой тренировке"
+        onChange={(evt) => setMessage(evt.target.value)}
       ></textarea>
 
-      <button className={styles.userNoteForm__sendButton}>Отправить</button>
-    </div>
+      <button type="submit" className={styles.userNoteForm__sendButton}>
+        Отправить
+      </button>
+    </form>
   );
 }
 

--- a/src/redux/services/combinedApi.ts
+++ b/src/redux/services/combinedApi.ts
@@ -54,5 +54,6 @@ const baseQueryWithRefresh: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQu
 
 export const combinedApi = createApi({
   baseQuery: baseQueryWithRefresh,
+  tagTypes: ['dietPlan'],
   endpoints: () => ({}),
 });

--- a/src/redux/services/dietApi.ts
+++ b/src/redux/services/dietApi.ts
@@ -24,6 +24,7 @@ export const dietApi = combinedApi.injectEndpoints({
           url: `diet-plans/${id}/`,
         };
       },
+      providesTags: ['dietPlan'],
     }),
     updateDietPlan: builder.mutation<TResponse, { id: number; data: IDietPlan }>({
       query(arg) {
@@ -34,6 +35,7 @@ export const dietApi = combinedApi.injectEndpoints({
           body: data,
         };
       },
+      invalidatesTags: ['dietPlan'],
     }),
     destroyDietPlan: builder.mutation<TResponse, number>({
       query(id) {

--- a/src/redux/types/diet.ts
+++ b/src/redux/types/diet.ts
@@ -8,9 +8,9 @@ interface IDietPlan {
   carbo?: number;
   fat?: number;
   describe?: string | null;
-  diet?: {
+  diet?: Array<{
     weekday: string;
     spec_comment?: string | null;
     user_comment?: string | null;
-  }[];
+  }>;
 }


### PR DESCRIPTION
Добавил возможность добавлять комменты к плану на странице по адресу /meal-plan?id=plan_id_here
Добавил тег dietPlan к combinedApi для инвалидации кеша при изменении плана.

П.С.: в текущей версии попасть на страницы через адресную строку невозможно (вы будете редирекнуты). Для проверки функциональности добавте в любое место проекта ссылку на /meal-plans и переходите по ней.